### PR TITLE
Enable Android 6 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,11 @@ nb-configuration.xml
 release.properties
 pom.xml.releaseBackup
 pom.xml.tag
+
+
+.gradle
+/local.properties
+/.idea
+/build
+/captures
+.externalNativeBuild

--- a/TSVNC/build.gradle
+++ b/TSVNC/build.gradle
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId "de.toshsoft.tsvnc"
-        minSdkVersion 24
+        minSdkVersion 23
         targetSdkVersion 29
         versionCode 21
         versionName '0.7.6'
@@ -23,6 +23,10 @@ android {
 
     kotlinOptions {
         jvmTarget = "1.8"
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/local.properties
+++ b/local.properties
@@ -1,9 +1,0 @@
-## This file must *NOT* be checked into Version Control Systems,
-# as it contains information specific to your local configuration.
-#
-# Location of the SDK. This is only used by Gradle.
-# For customization when using a Version Control System, please read the
-# header note.
-#Sat May 23 18:04:55 CEST 2020
-ndk.dir=/Users/opahl/Library/Android/sdk/ndk-bundle
-sdk.dir=/home/opahl/Development/Android/sdk


### PR DESCRIPTION
This pull request adds compatibility with Android 6 (tested in Andrid 6.0.1 in a GT-P1000).

I've also removed the `local.properties` as this file should not be tracked by git :-)